### PR TITLE
refactor into object literals, export a factory for todos

### DIFF
--- a/todo-parser.js
+++ b/todo-parser.js
@@ -1,31 +1,30 @@
 var Todo = require('./todo');
 
-TodoParser = {}
-TodoParser.parse = function (string) {
-  var regex_priority = /^\(([A-Z])\)/;
-  var regex_completed = /^x\s([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})\s+/i;
-  var regex_date = '';
-  var regex_context = '';
-  var regex_project = '';
+TodoParser = {
+  parse(string) {
+    var regex_priority = /^\(([A-Z])\)/;
+    var regex_completed = /^x\s([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})\s+/i;
+    var regex_date = '';
+    var regex_context = '';
+    var regex_project = '';
 
-  var priority = regex_priority.exec(string);
-  if (priority !== null) {
-    priority = priority[1];
-    string = string.replace(regex_priority, '');
+    var priority = regex_priority.exec(string);
+    if (priority !== null) {
+      priority = priority[1];
+      string = string.replace(regex_priority, '');
+    }
+    var completed = regex_completed.exec(string);
+    if (completed !== null) {
+      completed = completed[1];
+      string = string.replace(regex_completed, '');
+    }
+
+    string = this.trimWhitespace(string);
+    return Todo.create(string, priority, '', '', completed);
+  },
+  trimWhitespace(string) {
+    return string.trim();
   }
-  var completed = regex_completed.exec(string);
-  if (completed !== null) {
-    completed = completed[1];
-    string = string.replace(regex_completed, '');
-  }
-
-  string = TodoParser.trimWhitespace(string);
-
-  return new Todo(string, priority, '', '', completed);
-};
-
-TodoParser.trimWhitespace = function (string) {
-  return string.trim();
 }
 
 module.exports = TodoParser;

--- a/todo.js
+++ b/todo.js
@@ -20,7 +20,6 @@ var Todo = {
  */
 var TodoFactory = function() {
   var that = {},
-      store = [],
       /**
        * Init & Constructor function for our objects
        * @param  {[type]} text      [description]
@@ -33,20 +32,10 @@ var TodoFactory = function() {
       create = function(text, priority, project, contexts, completed) {
         var newTodo = Object.create(Todo);
         newTodo.init(text, priority, project, contexts, completed);
-        // in case we want to get a record of all Todo's init'd
-        store.push(newTodo);
         return newTodo;
       },
-      /**
-       * Returns all Todo's created with the factory
-       * @return Array
-       */
-      getAll = function() {
-        return store;
-      };
 
   that.create = create;
-  that.getAll = getAll;
   return that;
 }
 

--- a/todo.js
+++ b/todo.js
@@ -1,19 +1,55 @@
-function Todo(text, priority, project, contexts, completed) {
-  this.text = text;
-  this.priority = priority || '';
-  this.project = project || '';
-  this.contexts = contexts || [];
-  this.completed = !!completed;
-  this.completionDate = completed;
+var Todo = {
+  init(text, priority, project, contexts, completed) {
+    this.text = text;
+    this.priority = priority || '';
+    this.project = project || '';
+    this.contexts = contexts || [];
+    this.completed = !!completed;
+    this.completionDate = completed;
+  },
+  setCompleted() {
+    this.completed = true;
+  },
+  addContext(context) {
+    this.contexts.push(context);
+  }
 }
 
-Todo.prototype.setCompleted = function() {
-  this.completed = true;
-  return this;
+/**
+ * Factory function to help create our objects
+ */
+var TodoFactory = function() {
+  var that = {},
+      store = [],
+      /**
+       * Init & Constructor function for our objects
+       * @param  {[type]} text      [description]
+       * @param  {[type]} priority  [description]
+       * @param  {[type]} project   [description]
+       * @param  {[type]} contexts  [description]
+       * @param  {[type]} completed [description]
+       * @return {[type]}           [description]
+       */
+      create = function(text, priority, project, contexts, completed) {
+        var newTodo = Object.create(Todo);
+        newTodo.init(text, priority, project, contexts, completed);
+        // in case we want to get a record of all Todo's init'd
+        store.push(newTodo);
+        return newTodo;
+      },
+      /**
+       * Returns all Todo's created with the factory
+       * @return Array
+       */
+      getAll = function() {
+        return store;
+      };
+
+  that.create = create;
+  that.getAll = getAll;
+  return that;
 }
 
-Todo.prototype.addContext = function(context) {
-  this.contexts.push(context);
-}
+var todo = TodoFactory();
 
-module.exports = Todo;
+module.exports = todo;


### PR DESCRIPTION
Stylistic differences in handling JS objects, todo.js now exports a factory, avoiding using the `new` object creation method.

`var newTodo = new Todo(...params)`

becomes

`var newTodo = Todo.create(...params)`
